### PR TITLE
Updated CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Codeowners file, for details see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners
+
+* @govuk-one-login/digital-identity-leads


### PR DESCRIPTION
Add @govuk-one-login/digital-identity-leads as CODEOWNERS.